### PR TITLE
chore: rename crate to future-timing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 name: CI
 
 env:
+  RUSTFLAGS: -Dwarnings
   # Disable incremental compilation.
   #
   # Incremental compilation is useful as part of an edit-build-test-edit cycle,
@@ -40,7 +41,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --all --tests
 
   test_os:
     name: Tests on ${{ matrix.os }} with Rust ${{ matrix.rust }}
@@ -69,6 +70,21 @@ jobs:
 
       - name: Run cargo test
         run: cargo test
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run cargo check
+        run: cargo doc
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "future-timer"
+name = "future-timing"
 version = "0.1.0"
 dependencies = [
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "future-timer"
+name = "future-timing"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.70.0"
 authors = ["Hayden Stainsby <hds@caffeineconcepts.com>"]
 readme = "README.md"
-homepage = "https://github.com/hds/async-timing"
-repository = "https://github.com/hds/async-timing"
+homepage = "https://github.com/hds/future-timing"
+repository = "https://github.com/hds/future-timing"
 description = """
 Future timing instrumentation.
 
@@ -15,7 +15,13 @@ Instrumentation to record the busy and idle time taken by a future as it is driv
 completion.
 """
 categories = ["development-tools::debugging", "development-tools::profiling"]
-keywords = ["debugging", "async"]
+keywords = ["debugging", "async", "timing"]
+
+[lints.rust]
+missing_docs = "warn"
+missing_debug_implementations = "warn"
+rust_2018_idioms = "warn"
+unreachable_pub = "warn"
 
 [lints.clippy]
 cargo = "deny"
@@ -23,6 +29,9 @@ complexity = "deny"
 pedantic = "deny"
 perf = "deny"
 style = "deny"
+
+[lints.rustdoc]
+all = "deny"
 
 [dependencies]
 pin-project-lite = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# future-timer
+# future-timing
 
 Future timing instrumentation.
 
-This crate provides instrumentation to record the time taken by a future. This includes the
-busy time and the idle time.
+Provides instrumentation to record the time taken by a future. This includes the busy time and
+the idle time.
 
 ## Busy time
 
@@ -20,15 +20,13 @@ time before the first poll is not included.
 First, add this to your Cargo.toml `dependencies`:
 
 ```toml
-future-timer = "0.1"
+future-timing = "0.1"
 ```
 
 Record the timing of a future in the following manner.
 
-```rust
-use future_timer::FutureTimer;
-
-let output = FutureTimer::new(some_async_fn()).await;
+```
+let output = future_timing::timed(some_async_fn()).await;
 let (timing, future_output) = output.into_parts();
 
 do_something_with_output(future_output);
@@ -53,23 +51,22 @@ resolves after a specific period of time, then you're in the wrong place. Have a
 
 # Supported Rust Versions
 
-`future-timer` is built against the latest stable release. The minimum supported version is
-1.70. The current version of `future-timer` is not guaranteed to build on Rust versions earlier
+`future-timing` is built against the latest stable release. The minimum supported version is
+1.70. The current version of `future-timing` is not guaranteed to build on Rust versions earlier
 than the minimum supported version.
 
 # License
 
 This project is licensed under the [MIT license].
 
-[MIT license]: https://github.com/hds/future-timer/blob/main/LICENSE
-
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion
-in `future-timer` by you, shall be licensed as MIT, without any additional terms or conditions.
+in `future-timing` by you, shall be licensed as MIT, without any additional terms or conditions.
 
 [`async-timer`]: https://docs.rs/async-timer/latest/async_timer/
-[`RuntimeMetrics`]: struct@tokio::runtime::RuntimeMetrics
+['Future::poll`]: https://doc.rust-lang.org/std/future/trait.Future.html#tymethod.poll
+[`RuntimeMetrics`]: https://docs.rs/tokio/latest/tokio/runtime/struct.RuntimeMetrics.html
 [Tokio Console]: https://docs.rs/tokio-console/latest/tokio_console/
 [Tokio runtime]: https://docs.rs/tokio/latest/tokio/
-
+[MIT license]: https://github.com/hds/future-timing/blob/main/LICENSE

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -1,10 +1,15 @@
+//! Integration tests running on tokio runtime
+//!
+//! This crate isn't Tokio specific, and there's no reason why the timing functionality can't be
+//! used on a different runtime, but for the purpose of testing, this is the easiest way to get
+//! tests running.
 use std::time::Duration;
 
-use future_timer::FutureTimer;
+use future_timing::timed;
 
 #[tokio::test]
 async fn never_yield() {
-    let output = FutureTimer::new(async { 42 }).await;
+    let output = timed(async { 42 }).await;
     let timing = output.timing();
 
     assert!(timing.idle().is_zero());
@@ -14,7 +19,7 @@ async fn never_yield() {
 
 #[tokio::test]
 async fn short_async_sleep() {
-    let output = FutureTimer::new(async {
+    let output = timed(async {
         tokio::time::sleep(Duration::from_micros(10)).await;
         42
     })
@@ -28,7 +33,7 @@ async fn short_async_sleep() {
 
 #[tokio::test]
 async fn more_busy_time() {
-    let output = FutureTimer::new(async {
+    let output = timed(async {
         std::thread::sleep(Duration::from_micros(200));
 
         tokio::time::sleep(Duration::from_micros(10)).await;


### PR DESCRIPTION
We're interested in timing a future, and a timer may be considered more
something like a future that resolves after a specific time.

A number of types have also been renamed to simplify.

Building the docs has been added to the CI and the lints we're using
have been specified in the cargo manifest.